### PR TITLE
Warn users when using a class that could be a function

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -22,6 +22,7 @@
       }
     }],
     "jsx-quotes": ["error", "prefer-double"],
-    "react/jsx-curly-spacing": ["error", "never", { "allowMultiline": true }]
+    "react/jsx-curly-spacing": ["error", "never", { "allowMultiline": true }],
+    "react/prefer-stateless-function": 1
   }
 }


### PR DESCRIPTION
@DonnieWest 
Currently users are not warned when using an ES6 React Class that could be a function.

```(javascript)
class dumbComponent extends React.Component {
  render() {
    return (
      <div>{'I should be a function'}</div>
    );
  }
}
```

If merged users will receive the warning: `Component should be written as a pure function`